### PR TITLE
feat: auto-sync matchday photos via GitHub Actions

### DIFF
--- a/.github/workflows/sync-photos.yml
+++ b/.github/workflows/sync-photos.yml
@@ -1,0 +1,31 @@
+name: Sync Matchday Photos
+
+on:
+  schedule:
+    # Every 30 minutes
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: sync-photos
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm run sync-photos
+        env:
+          GOOGLE_DRIVE_FOLDER_ID: ${{ secrets.GOOGLE_DRIVE_FOLDER_ID }}
+          GOOGLE_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
+          GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY }}

--- a/scripts/sync-thumbnails.mjs
+++ b/scripts/sync-thumbnails.mjs
@@ -27,12 +27,12 @@ const GCS_BASE = `https://storage.googleapis.com/${BUCKET_NAME}/thumbnails`
 const THUMBNAIL_SIZES = [600, 1600]
 const CONCURRENCY = 3 // parallel uploads to avoid Drive rate limits
 
-// ── Load .env.local ──
+// ── Load env (.env.local for local dev, process.env for CI) ──
 const envPath = path.resolve(process.cwd(), '.env.local')
-const envContent = fs.readFileSync(envPath, 'utf-8')
+const envContent = fs.existsSync(envPath) ? fs.readFileSync(envPath, 'utf-8') : ''
 function getEnv(key) {
   const match = envContent.match(new RegExp(`^${key}=["']?(.*?)["']?$`, 'm'))
-  return match ? match[1] : ''
+  return match?.[1] || process.env[key] || ''
 }
 
 const FOLDER_ID = getEnv('GOOGLE_DRIVE_FOLDER_ID')


### PR DESCRIPTION
Runs sync-photos every 30 min and on-demand via workflow_dispatch. Sync script now falls back to process.env when .env.local is absent so it works in CI.