### PR TITLE
fix: resolve Search Console indexing issues

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import {AnnouncementBanner} from '../src/AnnouncementBanner'
 import {AnnouncementModal} from '../src/AnnouncementModal'
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://miamigooners.com'),
   title:
     'The Official Miami Arsenal FC Supporters Club in Miami, FL - Miami Gooners',
   description:

--- a/app/shop/cart/layout.tsx
+++ b/app/shop/cart/layout.tsx
@@ -1,0 +1,13 @@
+import type {Metadata} from 'next'
+
+export const metadata: Metadata = {
+  title: 'Cart - Miami Gooners Shop',
+  robots: {
+    index: false,
+    follow: true,
+  },
+}
+
+export default function CartLayout({children}: {children: React.ReactNode}) {
+  return children
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,6 +10,24 @@ const nextConfig = {
         destination: '/',
         permanent: false,
       },
+      {
+        source: '/pass',
+        destination: '/',
+        permanent: true,
+      },
+    ]
+  },
+  async headers() {
+    return [
+      {
+        source: '/api/:path*',
+        headers: [
+          {
+            key: 'X-Robots-Tag',
+            value: 'noindex, nofollow',
+          },
+        ],
+      },
     ]
   },
   images: {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,4 @@
 User-agent: *
 Allow: /
-Disallow: /_next/
-Disallow: /api/
 
 Sitemap: https://miamigooners.com/sitemap.xml


### PR DESCRIPTION
Fixes the indexing issues reported in Google Search Console.

- Removes the `Disallow: /_next/` rule from robots.txt, which was blocking Googlebot from loading JS/CSS and rendering pages (likely cause of "Crawled – currently not indexed").
- Replaces the `Disallow: /api/` robots.txt block with an `X-Robots-Tag: noindex, nofollow` header on all API routes, so Google can crawl them once and drop them from the index (fixes "Indexed, though blocked by robots.txt").
- Adds a permanent redirect from the removed `/pass` route to the home page (was returning 404 in production).
- Adds `metadataBase` to the root layout and noindexes the cart page via a new `app/shop/cart/layout.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)