### PR TITLE
feat: convey free shipping on orders over $50 across the shop

### DIFF
--- a/app/shop/ShopContent.tsx
+++ b/app/shop/ShopContent.tsx
@@ -11,13 +11,41 @@ import Link from 'next/link'
 import {Footer} from '../../src/Footer'
 import {ShopHero} from '../../src/ShopHero'
 import {ShopifyProduct, formatPrice} from '../../src/utils/shopify'
-import {doppler} from '../../src/font'
-import {ArrowForward} from '@mui/icons-material'
+import {doppler, inter} from '../../src/font'
+import {ArrowForward, LocalShipping} from '@mui/icons-material'
+import {FREE_SHIPPING_MESSAGE} from '../../src/constants/shipping'
 
 export default function ShopContent({products}: {products: ShopifyProduct[]}) {
   return (
     <>
       <ShopHero />
+
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 1,
+          py: 1.5,
+          px: 2,
+          backgroundColor: 'rgba(212,168,67,0.08)',
+          borderBottom: '1px solid rgba(212,168,67,0.3)',
+        }}
+      >
+        <LocalShipping sx={{fontSize: 18, color: '#D4A843'}} />
+        <Typography
+          sx={{
+            fontFamily: inter.style.fontFamily,
+            fontSize: {xs: '0.7rem', sm: '0.8rem'},
+            fontWeight: 600,
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            color: '#D4A843',
+          }}
+        >
+          {FREE_SHIPPING_MESSAGE}
+        </Typography>
+      </Box>
 
       <Container maxWidth="lg" sx={{pt: 4, pb: 4}}>
         {products.length === 0 ? (

--- a/app/shop/[productId]/ProductDetailClient.tsx
+++ b/app/shop/[productId]/ProductDetailClient.tsx
@@ -15,8 +15,9 @@ import {ShopHero} from '../../../src/ShopHero'
 import {ProductImageGallery} from '../../../src/ProductImageGallery'
 import {CartButton} from '../../../src/CartButton'
 import Grid from '@mui/material/Grid2'
-import {ArrowBack, ShoppingCart} from '@mui/icons-material'
+import {ArrowBack, ShoppingCart, LocalShipping} from '@mui/icons-material'
 import {ShopifyProduct, formatPrice} from '../../../src/utils/shopify'
+import {FREE_SHIPPING_MESSAGE} from '../../../src/constants/shipping'
 import {useState} from 'react'
 import {useCart} from '../../../src/context/CartContext'
 
@@ -138,6 +139,24 @@ export default function ProductDetailClient({
                   </Typography>
                 )}
               </Box>
+
+              {!product.tags.includes('local-pickup') && (
+                <Box
+                  component="div"
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    marginBottom: 3,
+                    color: '#D4A843',
+                  }}
+                >
+                  <LocalShipping sx={{fontSize: 18}} />
+                  <Typography variant="body2" sx={{fontWeight: 600}}>
+                    {FREE_SHIPPING_MESSAGE}
+                  </Typography>
+                </Box>
+              )}
 
               <Typography
                 variant="body1"

--- a/app/shop/cart/page.tsx
+++ b/app/shop/cart/page.tsx
@@ -19,12 +19,15 @@ import {
   ShoppingCart,
   Remove,
   Add,
+  LocalShipping,
+  CheckCircle,
 } from '@mui/icons-material'
 import {useCart} from '../../../src/context/CartContext'
 import {
   formatPrice,
   createCartWithMultipleItems,
 } from '../../../src/utils/shopify'
+import {FREE_SHIPPING_THRESHOLD} from '../../../src/constants/shipping'
 import {useState} from 'react'
 
 export default function Cart() {
@@ -71,6 +74,10 @@ export default function Cart() {
   const subtotal = state.items.reduce((total, item) => {
     return total + parseFloat(item.price.amount) * item.quantity
   }, 0)
+
+  const currencyCode = state.items[0]?.price.currencyCode || 'USD'
+  const qualifiesForFreeShipping = subtotal >= FREE_SHIPPING_THRESHOLD
+  const amountToFreeShipping = FREE_SHIPPING_THRESHOLD - subtotal
 
   if (state.items.length === 0) {
     return (
@@ -291,6 +298,31 @@ export default function Cart() {
                       subtotal.toString(),
                       state.items[0]?.price.currencyCode || 'USD'
                     )}
+                  </Typography>
+                </Box>
+
+                <Box
+                  component="div"
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    marginBottom: 1,
+                    color: qualifiesForFreeShipping ? '#22C55E' : '#D4A843',
+                  }}
+                >
+                  {qualifiesForFreeShipping ? (
+                    <CheckCircle sx={{fontSize: 18}} />
+                  ) : (
+                    <LocalShipping sx={{fontSize: 18}} />
+                  )}
+                  <Typography variant="body2" sx={{fontWeight: 600}}>
+                    {qualifiesForFreeShipping
+                      ? 'Your order qualifies for free shipping!'
+                      : `Add ${formatPrice(
+                          amountToFreeShipping.toString(),
+                          currencyCode
+                        )} more for free shipping`}
                   </Typography>
                 </Box>
 

--- a/src/constants/shipping.ts
+++ b/src/constants/shipping.ts
@@ -1,0 +1,4 @@
+// Free shipping promotion — keep the threshold and copy in one place.
+export const FREE_SHIPPING_THRESHOLD = 50
+export const FREE_SHIPPING_CURRENCY = 'USD'
+export const FREE_SHIPPING_MESSAGE = 'Free shipping on orders over $50'


### PR DESCRIPTION
## Summary

Surfaces the "free shipping on orders over \$50" offer to users throughout the shop, so shipping cost is no longer a surprise at checkout.

- **New constant** — `src/constants/shipping.ts` centralizes `FREE_SHIPPING_THRESHOLD` (50) and the promo copy.
- **Shop listing** — slim gold-accented banner below the hero with a `LocalShipping` icon.
- **Product detail** — gold callout under the price, shown only for shippable products (preserves the existing `local-pickup` guard).
- **Cart** — dynamic order-summary line: gold "Add \$X more for free shipping" when under \$50 (using `formatPrice` for the remaining amount), switching to a green "Your order qualifies for free shipping!" once the subtotal reaches \$50.

## Verification

- `npm run build` passes with clean TypeScript type-checking and static generation.
- Note: `npm run lint` fails because `next lint` was removed in Next 16 — a pre-existing repo issue unrelated to this change.

Manual checks to run:
1. `/shop` — banner shows below the hero.
2. `/shop/[productId]` — callout appears; a `local-pickup`-tagged product does not show it.
3. Cart subtotal under \$50 — "Add \$X more" nudge with correct remaining amount.
4. Cart subtotal ≥ \$50 — switches to the qualifying success state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)