### PR TITLE
feat: add 2026 pre-season fixtures, results, and a pre-season filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,7 @@ Fixtures come from two sources, both handled in `src/utils/events.ts`:
 | FA Cup | `public/fixtures/fa-cup-25-26.json` | Local file. Edit by hand. |
 | Carabao Cup | `public/fixtures/carabao-cup-25-26.json` | Local file. Edit by hand. |
 
-Pre-season friendlies are hard-coded in the `preSeason25` array in `src/utils/events.ts`.
+Pre-season friendlies are hard-coded in the `preSeason` array in `src/utils/events.ts`, and the Community Shield in the `communityShield26` array in the same file. Both are edited by hand — scores included.
 
 If a remote feed fails, that competition is silently omitted from the events list (no local fallback file is read).
 

--- a/src/AllEvents.tsx
+++ b/src/AllEvents.tsx
@@ -18,11 +18,19 @@ import {doppler} from './font'
 
 const COMPETITION_FILTERS = [
   'All',
+  'Pre-season',
   'Premier League',
   'UEFA Champions League',
   'FA Cup',
   'Carabao Cup',
 ] as const
+
+// Competitions grouped under the single "Pre-season" chip
+const PRE_SEASON_COMPETITIONS = [
+  'Pre-season Friendly',
+  'Emirates Cup',
+  'FA Community Shield',
+]
 
 type FilterType = (typeof COMPETITION_FILTERS)[number]
 
@@ -63,6 +71,10 @@ export const AllEvents = ({events, photoMatchMap = {}}: {events: EventType[]; ph
 
   const filterEvents = (list: EventType[]) => {
     if (filter === 'All') return list
+    if (filter === 'Pre-season')
+      return list.filter(
+        (e) => e.competition && PRE_SEASON_COMPETITIONS.includes(e.competition)
+      )
     return list.filter((e) => e.competition === filter)
   }
 

--- a/src/constants/teamColors.ts
+++ b/src/constants/teamColors.ts
@@ -231,4 +231,19 @@ export const teamColors: TeamColors[] = [
     secondary: '#FFFFFF',
     team: 'Real Betis',
   },
+  {
+    primary: '#D8232A',
+    secondary: '#FFFFFF',
+    team: 'Girona',
+  },
+  {
+    primary: '#FDE100',
+    secondary: '#000000',
+    team: 'Borussia Dortmund',
+  },
+  {
+    primary: '#005BAC',
+    secondary: '#FFFFFF',
+    team: 'Como',
+  },
 ]

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -9,7 +9,7 @@ const EPL_URLS = [
 const UCL_URL =
   'https://fixturedownload.com/feed/json/champions-league-2025/arsenal'
 
-const preSeason25: EventType[] = [
+const preSeason: EventType[] = [
   {
     MatchNumber: 1,
     RoundNumber: 1,
@@ -17,15 +17,48 @@ const preSeason25: EventType[] = [
     Location: 'Emirates Stadium',
     HomeTeam: 'Arsenal',
     AwayTeam: 'Athletic Club',
+    HomeTeamScore: 3,
+    AwayTeamScore: 0,
     competition: 'Emirates Cup',
   },
   {
     MatchNumber: 2,
     RoundNumber: 1,
+    DateUtc: '2026-08-01 18:00:00Z',
+    Location: 'Estadi Montilivi',
+    HomeTeam: 'Girona',
+    AwayTeam: 'Arsenal',
+    HomeTeamScore: 1,
+    AwayTeamScore: 4,
+    competition: 'Pre-season Friendly',
+  },
+  {
+    MatchNumber: 3,
+    RoundNumber: 1,
     DateUtc: '2026-08-05 18:30:00Z',
     Location: 'Aviva Stadium',
     HomeTeam: 'Arsenal',
     AwayTeam: 'Real Betis',
+    HomeTeamScore: 1,
+    AwayTeamScore: 3,
+    competition: 'Pre-season Friendly',
+  },
+  {
+    MatchNumber: 4,
+    RoundNumber: 1,
+    DateUtc: '2026-08-09 13:00:00Z',
+    Location: 'Emirates Stadium',
+    HomeTeam: 'Arsenal',
+    AwayTeam: 'Borussia Dortmund',
+    competition: 'Emirates Cup',
+  },
+  {
+    MatchNumber: 5,
+    RoundNumber: 1,
+    DateUtc: '2026-08-12 18:30:00Z',
+    Location: 'Emirates Stadium',
+    HomeTeam: 'Arsenal',
+    AwayTeam: 'Como',
     competition: 'Pre-season Friendly',
   },
 ]
@@ -80,7 +113,7 @@ export async function getAllEvents(): Promise<EventType[]> {
   ).map((event: EventType) => ({competition: 'FA Cup', ...event}))
 
   return [
-    ...preSeason25,
+    ...preSeason,
     ...communityShield26,
     ...plSeason25,
     ...uclSeason25,


### PR DESCRIPTION
## Why

Arsenal's 2026/27 pre-season is three matches deep, but the site only knew about one of them. The Girona, Borussia Dortmund and Como matches were missing entirely, and the Real Betis friendly had been played on 5 Aug without its result ever being recorded — so its past-match card rendered with a blank score and no result badge.

Pre-season friendlies are hard-coded in `src/utils/events.ts` (unlike Premier League and UCL, which come from fixturedownload.com), so this had to be a manual edit.

## Fixtures added / updated

| Date | Match | Venue | Competition | Result |
|---|---|---|---|---|
| 9 Aug 2025 | Arsenal v Athletic Club | Emirates Stadium | Emirates Cup | **3-0 W** (backfilled) |
| 1 Aug 2026 | Girona v Arsenal | Estadi Montilivi | Pre-season Friendly | **1-4 W** (new) |
| 5 Aug 2026 | Arsenal v Real Betis | Aviva Stadium | Pre-season Friendly | **1-3 L** (score added) |
| 9 Aug 2026 | Arsenal v Borussia Dortmund | Emirates Stadium | Emirates Cup | upcoming (new) |
| 12 Aug 2026 | Arsenal v Como | Emirates Stadium | Pre-season Friendly | upcoming (new) |

Kick-off times were sourced in UK local time and converted to UTC at BST (UTC+1). The 25 Jul MK Dons win (3-0) is deliberately excluded — it was behind closed doors at the Sobha Realty Training Centre, so it isn't a match members could attend or watch.

## Changes

- **`src/utils/events.ts`** — populated the pre-season array with the five matches above and renamed `preSeason25` → `preSeason`, since it now spans two seasons. Girona is Arsenal's first away friendly in the array; `getScoreDisplay()` and `getResult()` in `Event.tsx` already handle the home/away swap, so no component work was needed.
- **`src/constants/teamColors.ts`** — added Girona, Borussia Dortmund and Como. Team lookup is an exact string match with a grey `#3A3A46` fallback, so without these the three new cards would have rendered colorless.
- **`src/AllEvents.tsx`** — added a **Pre-season** filter chip grouping `Pre-season Friendly`, `Emirates Cup` and `FA Community Shield`. These three competitions had no chip of their own, so with six such matches now on the page they were reachable only under "All".
- **`CLAUDE.md`** — updated the stale `preSeason25` reference and documented `communityShield26`, which wasn't mentioned in the fixture-update section.

## Verification

- `npx tsc --noEmit` passes clean.
- `next build` compiles and typechecks successfully. Page-data collection fails on `/shop/[productId]` because `SHOPIFY_STORE_DOMAIN` is unset in this environment — pre-existing and unrelated to this diff. (`npm run lint` is also broken on `main`: `next lint` was removed in Next 16.)
- Verified against a running dev server — `/api/events` returns all six pre-season entries in date order with correct scores.
- Checked the rendered page: Girona shows `4 - 1` with a **W** badge (Arsenal's goals first despite being the away side), Real Betis `1 - 3` with **L**, Athletic Club `3 - 0` with **W**. Dortmund, Como and the Community Shield appear under Upcoming with live countdowns. ET conversions confirmed (Dortmund displays 9:00AM ET = 14:00 BST).
- Drove the new chip in a browser: **Pre-season** narrows to exactly those six, and every other chip filters as before. Dortmund's yellow band renders legibly against the card.