### PR TITLE
Add cookie consent, correct the privacy policy, and stop publishing contributor emails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,6 @@ npm run sync-photos
 - **Framework**: Next.js 16 (App Router, Turbopack) with TypeScript
 - **UI**: Material-UI v6 (@mui/material) with Emotion for styling
 - **Particle Animation**: Three.js with React Three Fiber (@react-three/fiber 9.x) + Drei (@react-three/drei 10.x) — particles only, no 3D models
-- **Authentication**: Auth0 v4 (@auth0/nextjs-auth0)
 - **E-commerce**: Shopify Storefront API 2026-01 (@shopify/storefront-api-client)
 - **Date Handling**: Luxon for timezone-aware date formatting
 - **Photos Storage**: Google Cloud Storage (thumbnails + manifest JSON)
@@ -46,7 +45,7 @@ app/
 ├── not-found.tsx           # 404 page
 ├── ThemeRegistry.tsx       # 'use client' — Emotion cache + MUI ThemeProvider
 ├── NavigationLoader.tsx    # 'use client' — loading overlay on navigation
-├── Providers.tsx           # 'use client' — Auth0Provider + CartProvider
+├── Providers.tsx           # 'use client' — CartProvider
 ├── matchday-photos/
 │   ├── page.tsx            # Server Component — fetches manifest + events, enriches matches
 │   └── PhotosContent.tsx   # 'use client' — filter bar, grid, lightbox orchestrator
@@ -97,10 +96,6 @@ src/
 scripts/
 └── sync-thumbnails.mjs     # Syncs photos from Google Drive to GCS + generates manifest
 
-lib/
-└── auth0.ts                # Auth0Client singleton
-
-proxy.ts                    # Auth0 middleware (replaces middleware.ts)
 styles/globals.css          # Tailwind @theme tokens, CSS animations, global styles
 public/fixtures/
 ├── carabao-cup-25-26.json     # Carabao Cup fixture data (local)
@@ -196,13 +191,6 @@ Photos from matchday events are stored in Google Drive (organized as subfolders 
 Match dates stored in UTC (`"yyyy-MM-dd HH:mm:ss'Z'"`) and converted to `America/New_York` timezone via Luxon.
 
 ## Environment Variables
-
-Auth0:
-- `AUTH0_SECRET`
-- `AUTH0_BASE_URL`
-- `AUTH0_ISSUER_BASE_URL`
-- `AUTH0_CLIENT_ID`
-- `AUTH0_CLIENT_SECRET`
 
 Shopify:
 - `SHOPIFY_STORE_DOMAIN` (your-store.myshopify.com)

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import {SpeedInsights} from '@vercel/speed-insights/next'
 import {Navbar} from '../src/Navbar'
 import {AnnouncementBanner} from '../src/AnnouncementBanner'
 import {AnnouncementModal} from '../src/AnnouncementModal'
+import {CookieConsentBanner} from '../src/CookieConsentBanner'
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://miamigooners.com'),
@@ -84,18 +85,41 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
         />
       </head>
       <body>
-        {/* eslint-disable-next-line @next/next/no-sync-scripts */}
-        <script
-          async
-          src="https://www.googletagmanager.com/gtag/js?id=G-1ZGEWQ7JLM"
-        />
+        {/*
+          Google Consent Mode v2. Until analytics_storage is granted, GA4 sets no
+          cookies and sends only cookieless pings. Returning visitors who already
+          accepted are read straight from localStorage, so there's no flicker and
+          no lost pageview.
+
+          The gtag loader is injected from here rather than written as a JSX
+          <script async src>: React hoists those into <head>, which would let the
+          library run before this consent default is queued. Creating the element
+          ourselves keeps the order deterministic — consent, then config, then load.
+        */}
         <script
           dangerouslySetInnerHTML={{
             __html: `
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
+              var mgConsent = 'denied';
+              try {
+                if (localStorage.getItem('miami-gooners-cookie-consent-v1') === 'granted') {
+                  mgConsent = 'granted';
+                }
+              } catch (e) {}
+              gtag('consent', 'default', {
+                analytics_storage: mgConsent,
+                ad_storage: 'denied',
+                ad_user_data: 'denied',
+                ad_personalization: 'denied',
+                wait_for_update: 500
+              });
               gtag('js', new Date());
               gtag('config', 'G-1ZGEWQ7JLM');
+              var mgTag = document.createElement('script');
+              mgTag.async = true;
+              mgTag.src = 'https://www.googletagmanager.com/gtag/js?id=G-1ZGEWQ7JLM';
+              document.head.appendChild(mgTag);
             `,
           }}
         />
@@ -106,6 +130,7 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
             <Navbar />
             {children}
             <AnnouncementModal />
+            <CookieConsentBanner />
             <SpeedInsights />
           </Providers>
         </ThemeRegistry>

--- a/scripts/sync-thumbnails.mjs
+++ b/scripts/sync-thumbnails.mjs
@@ -146,7 +146,7 @@ async function listFilesInFolder(folderId) {
     const res = await drive.files.list({
       q: `'${folderId}' in parents and trashed = false and (mimeType contains 'image/' or mimeType contains 'video/')`,
       fields:
-        'nextPageToken, files(id,name,mimeType,description,createdTime,webViewLink,webContentLink,size,imageMediaMetadata(width,height),videoMediaMetadata(width,height,durationMillis),owners(displayName,emailAddress,photoLink))',
+        'nextPageToken, files(id,name,mimeType,description,createdTime,webViewLink,webContentLink,size,imageMediaMetadata(width,height),videoMediaMetadata(width,height,durationMillis),owners(displayName,photoLink))',
       orderBy: 'createdTime desc',
       pageSize: 100,
       pageToken,
@@ -180,9 +180,10 @@ function mapDriveFile(f) {
           durationMillis: String(f.videoMediaMetadata.durationMillis ?? '0'),
         }
       : undefined,
+    // Only displayName is ever shown (photo credits). Contributor email
+    // addresses must not enter the manifest — it is a public GCS object.
     owners: (f.owners ?? []).map((o) => ({
       displayName: o.displayName ?? '',
-      emailAddress: o.emailAddress ?? '',
       photoLink: o.photoLink ?? undefined,
     })),
   }

--- a/src/CookieConsentBanner.tsx
+++ b/src/CookieConsentBanner.tsx
@@ -1,0 +1,138 @@
+'use client'
+import {useEffect, useState} from 'react'
+import {Box, Button, Typography} from '@mui/material'
+import {PolicyModal} from './PolicyModal'
+import {PrivacyPolicy} from './policies/PrivacyPolicy'
+import {
+  CONSENT_OPEN_EVENT,
+  ConsentValue,
+  readConsent,
+  updateGtagConsent,
+  writeConsent,
+} from './utils/consent'
+import {inter} from './font'
+
+export const CookieConsentBanner = () => {
+  const [visible, setVisible] = useState(false)
+  const [privacyPolicyOpen, setPrivacyPolicyOpen] = useState(false)
+
+  // Start hidden and reveal in an effect — the server can't know localStorage,
+  // so rendering the banner during SSR would cause a hydration mismatch.
+  //
+  // A Global Privacy Control signal is itself an opt-out, which our Privacy
+  // Policy commits to honouring, so we don't ask. Consent already defaults to
+  // denied; the footer link still lets those visitors opt in deliberately.
+  useEffect(() => {
+    if (readConsent() !== null) return
+    if (navigator.globalPrivacyControl === true) return
+    setVisible(true)
+  }, [])
+
+  // Lets the footer's "Cookie Preferences" link reopen the banner after a choice.
+  useEffect(() => {
+    const handler = () => setVisible(true)
+    window.addEventListener(CONSENT_OPEN_EVENT, handler)
+    return () => window.removeEventListener(CONSENT_OPEN_EVENT, handler)
+  }, [])
+
+  const choose = (value: ConsentValue) => {
+    writeConsent(value)
+    updateGtagConsent(value)
+    setVisible(false)
+  }
+
+  if (!visible) return null
+
+  return (
+    <>
+      <Box
+        role="region"
+        aria-label="Cookie consent"
+        sx={{
+          position: 'fixed',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          zIndex: 1200,
+          backgroundColor: '#111113',
+          borderTop: '1px solid #2E2E38',
+          boxShadow: '0 -8px 32px rgba(0,0,0,0.5)',
+          px: {xs: 2, md: 4},
+          py: {xs: 2, md: 2.5},
+          display: 'flex',
+          flexDirection: {xs: 'column', md: 'row'},
+          alignItems: {xs: 'stretch', md: 'center'},
+          justifyContent: 'center',
+          gap: {xs: 1.5, md: 3},
+          fontFamily: inter.style.fontFamily,
+          animation: 'fadeSlideUp 0.3s ease-out',
+        }}
+      >
+        <Typography
+          sx={{
+            fontFamily: inter.style.fontFamily,
+            fontSize: {xs: '0.8125rem', md: '0.875rem'},
+            color: '#A1A1AA',
+            lineHeight: 1.5,
+            maxWidth: 640,
+          }}
+        >
+          We use cookies to measure how the site is used. Analytics cookies are
+          only set if you accept — rejecting keeps everything working.{' '}
+          <Box
+            component="button"
+            onClick={() => setPrivacyPolicyOpen(true)}
+            sx={{
+              background: 'none',
+              border: 'none',
+              padding: 0,
+              color: '#D4A843',
+              fontFamily: 'inherit',
+              fontSize: 'inherit',
+              cursor: 'pointer',
+              textDecoration: 'underline',
+              textUnderlineOffset: 3,
+            }}
+          >
+            Privacy Policy
+          </Box>
+        </Typography>
+
+        {/* Equal prominence for both choices — rejecting must be as easy as accepting. */}
+        <Box
+          sx={{
+            display: 'flex',
+            gap: 1.5,
+            flexShrink: 0,
+            '& > *': {flex: {xs: 1, md: '0 0 auto'}},
+          }}
+        >
+          <Button
+            onClick={() => choose('denied')}
+            variant="outlined"
+            color="primary"
+            sx={{minWidth: {md: 120}}}
+          >
+            Reject
+          </Button>
+          <Button
+            onClick={() => choose('granted')}
+            variant="contained"
+            color="primary"
+            sx={{minWidth: {md: 120}}}
+          >
+            Accept
+          </Button>
+        </Box>
+      </Box>
+
+      <PolicyModal
+        open={privacyPolicyOpen}
+        onClose={() => setPrivacyPolicyOpen(false)}
+        title="Privacy Policy"
+      >
+        <PrivacyPolicy />
+      </PolicyModal>
+    </>
+  )
+}

--- a/src/CookieConsentBanner.tsx
+++ b/src/CookieConsentBanner.tsx
@@ -1,5 +1,5 @@
 'use client'
-import {useEffect, useState} from 'react'
+import {useEffect, useRef, useState} from 'react'
 import {Box, Button, Typography} from '@mui/material'
 import {PolicyModal} from './PolicyModal'
 import {PrivacyPolicy} from './policies/PrivacyPolicy'
@@ -15,12 +15,32 @@ import {inter} from './font'
 export const CookieConsentBanner = () => {
   const [visible, setVisible] = useState(false)
   const [privacyPolicyOpen, setPrivacyPolicyOpen] = useState(false)
+  const bannerRef = useRef<HTMLDivElement>(null)
+
+  // The banner is fixed to the bottom, so without this it sits on top of the
+  // footer's policy links and swallows clicks on them until a choice is made.
+  useEffect(() => {
+    if (!visible) {
+      document.body.style.removeProperty('padding-bottom')
+      return
+    }
+    const apply = () => {
+      const height = bannerRef.current?.offsetHeight
+      if (height) document.body.style.paddingBottom = `${height}px`
+    }
+    apply()
+    window.addEventListener('resize', apply)
+    return () => {
+      window.removeEventListener('resize', apply)
+      document.body.style.removeProperty('padding-bottom')
+    }
+  }, [visible])
 
   // Start hidden and reveal in an effect — the server can't know localStorage,
   // so rendering the banner during SSR would cause a hydration mismatch.
   //
   // A Global Privacy Control signal is itself an opt-out, which our Privacy
-  // Policy commits to honouring, so we don't ask. Consent already defaults to
+  // Policy commits to honoring, so we don't ask. Consent already defaults to
   // denied; the footer link still lets those visitors opt in deliberately.
   useEffect(() => {
     if (readConsent() !== null) return
@@ -46,6 +66,7 @@ export const CookieConsentBanner = () => {
   return (
     <>
       <Box
+        ref={bannerRef}
         role="region"
         aria-label="Cookie consent"
         sx={{

--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -7,6 +7,7 @@ import {PrivacyPolicy} from './policies/PrivacyPolicy'
 import {Box, Container, IconButton, Typography} from '@mui/material'
 import {Instagram, X, Mail} from '@mui/icons-material'
 import {doppler} from './font'
+import {CONSENT_OPEN_EVENT} from './utils/consent'
 
 export const Footer = () => {
   const [returnPolicyOpen, setReturnPolicyOpen] = useState(false)
@@ -239,6 +240,24 @@ export const Footer = () => {
                 }}
               >
                 Return Policy
+              </button>
+              <Typography variant="caption" sx={{color: '#2E2E38'}}>
+                |
+              </Typography>
+              <button
+                onClick={() =>
+                  window.dispatchEvent(new Event(CONSENT_OPEN_EVENT))
+                }
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  color: '#71717A',
+                  fontSize: '0.75rem',
+                  cursor: 'pointer',
+                  padding: 0,
+                }}
+              >
+                Cookie Preferences
               </button>
             </Box>
           </Box>

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -113,22 +113,27 @@ const CartContext = createContext<CartContextType | undefined>(undefined)
 export function CartProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(cartReducer, initialState)
 
-  // Load cart from localStorage on mount
+  // Load cart from localStorage on mount. Accessing localStorage throws outright
+  // when storage is blocked (Safari private mode, "block all cookies"), so the
+  // guard has to wrap the access itself, not just the JSON parse.
   useEffect(() => {
-    const savedCart = localStorage.getItem('miami-gooners-cart')
-    if (savedCart) {
-      try {
-        const items = JSON.parse(savedCart)
-        dispatch({ type: 'LOAD_CART', items })
-      } catch (error) {
-        console.error('Error loading cart from localStorage:', error)
+    try {
+      const savedCart = localStorage.getItem('miami-gooners-cart')
+      if (savedCart) {
+        dispatch({ type: 'LOAD_CART', items: JSON.parse(savedCart) })
       }
+    } catch (error) {
+      console.error('Error loading cart from localStorage:', error)
     }
   }, [])
 
   // Save cart to localStorage whenever it changes
   useEffect(() => {
-    localStorage.setItem('miami-gooners-cart', JSON.stringify(state.items))
+    try {
+      localStorage.setItem('miami-gooners-cart', JSON.stringify(state.items))
+    } catch {
+      // storage unavailable or full — the cart still works for this session
+    }
   }, [state.items])
 
   const addItem = (item: Omit<CartItem, 'quantity'>) => {

--- a/src/policies/PrivacyPolicy.tsx
+++ b/src/policies/PrivacyPolicy.tsx
@@ -4,7 +4,7 @@ export const PrivacyPolicy = () => {
   return (
     <>
       <Typography variant="body2" color="text.secondary" paragraph>
-        Last updated: February 27, 2026
+        Last updated: August 8, 2026
       </Typography>
 
       <Typography paragraph>
@@ -81,6 +81,26 @@ export const PrivacyPolicy = () => {
         <Link href="https://www.shopify.com/legal/privacy/customers" target="_blank" rel="noopener noreferrer">
           Shopify Consumer Privacy Policy
         </Link>.
+      </Typography>
+
+      <Typography variant="h6" fontWeight="bold" gutterBottom sx={{marginTop: 3}}>
+        Cookies and Similar Technologies
+      </Typography>
+      <Typography paragraph>
+        We use a small number of cookies and similar browser storage technologies on miamigooners.com. Some are necessary for the site to function; analytics cookies are only set if you choose to accept them.
+      </Typography>
+      <Typography component="ul" sx={{paddingLeft: 2}}>
+        <li><strong>Google Analytics (<code>_ga</code>, <code>_ga_G-1ZGEWQ7JLM</code>) — analytics, up to 2 years.</strong> Helps us understand which pages and matches people visit. These are only set after you select "Accept" in our cookie banner. If you reject or have not yet chosen, Google Analytics runs in a restricted mode that stores nothing on your device.</li>
+        <li><strong>Shopping cart (<code>miami-gooners-cart</code>) — strictly necessary, stored until cleared.</strong> Browser local storage that remembers the items in your cart between visits. Without it the shop cannot work.</li>
+        <li><strong>Cookie choice (<code>miami-gooners-cookie-consent-v1</code>) — strictly necessary, stored until cleared.</strong> Records whether you accepted or rejected analytics so we do not ask again.</li>
+        <li><strong>Announcement dismissal — functional, stored until cleared.</strong> Remembers that you have closed a site announcement.</li>
+        <li><strong>Vercel Speed Insights — no cookies.</strong> Our hosting provider collects anonymous page performance measurements. It sets no cookies and does not identify you.</li>
+      </Typography>
+      <Typography paragraph>
+        Two features load content from other companies only when you ask for them. Playing a match video in our photo gallery loads a video player from Google Drive, and starting checkout takes you to Shopify's own checkout pages. Both may set their own cookies at that point, governed by Google's and Shopify's privacy policies rather than this one.
+      </Typography>
+      <Typography paragraph>
+        You can change your choice at any time using the <strong>Cookie Preferences</strong> link at the bottom of any page, or by clearing the site data in your browser settings.
       </Typography>
 
       <Typography variant="h6" fontWeight="bold" gutterBottom sx={{marginTop: 3}}>

--- a/src/policies/PrivacyPolicy.tsx
+++ b/src/policies/PrivacyPolicy.tsx
@@ -8,7 +8,7 @@ export const PrivacyPolicy = () => {
       </Typography>
 
       <Typography paragraph>
-        Miami Gooners Shop operates this store and website, including all related information, content, features, tools, products and services, in order to provide you, the customer, with a curated shopping experience (the "Services"). Miami Gooners Shop is powered by Shopify, which enables us to provide the Services to you. This Privacy Policy describes how we collect, use, and disclose your personal information when you visit, use, or make a purchase or other transaction using the Services or otherwise communicate with us. If there is a conflict between our Terms of Service and this Privacy Policy, this Privacy Policy controls with respect to the collection, processing, and disclosure of your personal information.
+        Miami Gooners is the official Arsenal FC supporters club in Miami, Florida. We operate miamigooners.com, including our match listings, matchday photo gallery, and online shop (together, the "Services"). This Privacy Policy describes how we collect, use, and disclose your personal information when you visit or use the Services, buy merchandise from us, or otherwise communicate with us. Our shop is powered by Shopify, and when you buy something you complete your order on Shopify's own checkout pages — see "Relationship with Shopify" below.
       </Typography>
 
       <Typography paragraph>
@@ -23,10 +23,10 @@ export const PrivacyPolicy = () => {
       </Typography>
 
       <Typography component="ul" sx={{paddingLeft: 2}}>
-        <li>Contact details including your name, address, billing address, shipping address, phone number, and email address.</li>
-        <li>Financial information including credit card, debit card, and financial account numbers, payment card information, financial account information, transaction details, form of payment, payment confirmation and other payment details.</li>
-        <li>Account information including your username, password, security questions, preferences and settings.</li>
-        <li>Transaction information including the items you view, put in your cart, add to your wishlist, or purchase, return, exchange or cancel and your past transactions.</li>
+        <li>Contact details including your name, shipping address, billing address, phone number, and email address. This website does not ask you for any of these — they are collected by Shopify when you check out, and shared back with us so we can fulfill your order.</li>
+        <li>Financial information including payment card and payment account details. These are collected and processed entirely by Shopify and its payment processors on their own checkout pages. We never receive or store your full card details.</li>
+        <li>Transaction information including the items you view, put in your cart, or purchase, return, exchange or cancel, and your past transactions.</li>
+        <li>Photographs and contributor names, where you appear in or have contributed images to our matchday photo gallery. See "Matchday Photos" below.</li>
         <li>Communications with us including the information you include in communications with us, for example, when sending a customer support inquiry.</li>
         <li>Device information including information about your device, browser, or network connection, your IP address, and other unique identifiers.</li>
         <li>Usage information including information regarding your interaction with the Services, including how and when you interact with or navigate the Services.</li>
@@ -39,7 +39,7 @@ export const PrivacyPolicy = () => {
         We may collect personal information from the following sources:
       </Typography>
       <Typography component="ul" sx={{paddingLeft: 2}}>
-        <li>Directly from you including when you create an account, visit or use the Services, communicate with us, or otherwise provide us with your personal information;</li>
+        <li>Directly from you including when you visit or use the Services, place an order, communicate with us, or otherwise provide us with your personal information;</li>
         <li>Automatically through the Services including from your device when you use our products or services or visit our websites, and through the use of cookies and similar technologies;</li>
         <li>From our service providers including when we engage them to enable certain technology and when they collect or process your personal information on our behalf;</li>
         <li>From our partners or other third parties.</li>
@@ -52,9 +52,8 @@ export const PrivacyPolicy = () => {
         Depending on how you interact with us or which of the Services you use, we may use personal information for the following purposes:
       </Typography>
       <Typography component="ul" sx={{paddingLeft: 2}}>
-        <li><strong>Provide, Tailor, and Improve the Services.</strong> We use your personal information to provide you with the Services, including to perform our contract with you, to process your payments, to fulfill your orders, to remember your preferences and items you are interested in, to send notifications to you related to your account, to process purchases, returns, exchanges or other transactions, to create, maintain and otherwise manage your account, to arrange for shipping, to facilitate any returns and exchanges, to enable you to post reviews, and to create a customized shopping experience for you, such as recommending products related to your purchases. This may include using your personal information to better tailor and improve the Services.</li>
-        <li><strong>Marketing and Advertising.</strong> We use your personal information for marketing and promotional purposes, such as to send marketing, advertising and promotional communications by email, text message or postal mail, and to show you online advertisements for products or services on the Services or other websites, including based on items you previously have purchased or added to your cart and other activity on the Services.</li>
-        <li><strong>Security and Fraud Prevention.</strong> We use your personal information to authenticate your account, to provide a secure payment and shopping experience, detect, investigate or take action regarding possible fraudulent, illegal, unsafe, or malicious activity, protect public safety, and to secure our services. If you choose to use the Services and register an account, you are responsible for keeping your account credentials safe. We highly recommend that you do not share your username, password or other access details with anyone else.</li>
+        <li><strong>Provide, Tailor, and Improve the Services.</strong> We use your personal information to provide you with the Services, including to perform our contract with you, to process your payments, to fulfill your orders, to process purchases, returns, exchanges or other transactions, to arrange for shipping, and to facilitate any returns and exchanges. This may include using your personal information to better tailor and improve the Services.</li>
+        <li><strong>Security and Fraud Prevention.</strong> We use your personal information to provide a secure payment and shopping experience, to detect, investigate or take action regarding possible fraudulent, illegal, unsafe, or malicious activity, to protect public safety, and to secure our services.</li>
         <li><strong>Communicating with You.</strong> We use your personal information to provide you with customer support, to be responsive to you, to provide effective services to you and to maintain our business relationship with you.</li>
         <li><strong>Legal Reasons.</strong> We use your personal information to comply with applicable law or respond to valid legal process, including requests from law enforcement or government agencies, to investigate or participate in civil discovery, potential or actual litigation, or other adversarial legal proceedings, and to enforce or investigate potential violations of our terms or policies.</li>
       </Typography>
@@ -66,18 +65,16 @@ export const PrivacyPolicy = () => {
         In certain circumstances, we may disclose your personal information to third parties for legitimate purposes subject to this Privacy Policy. Such circumstances may include:
       </Typography>
       <Typography component="ul" sx={{paddingLeft: 2}}>
-        <li>With Shopify, vendors and other third parties who perform services on our behalf (e.g. IT management, payment processing, data analytics, customer support, cloud storage, fulfillment and shipping).</li>
-        <li>With business and marketing partners to provide marketing services and advertise to you. For example, we use Shopify to support personalized advertising with third-party services based on your online activity with different merchants and websites. Our business and marketing partners will use your information in accordance with their own privacy notices.</li>
-        <li>When you direct, request us or otherwise consent to our disclosure of certain information to third parties, such as to ship you products or through your use of social media widgets or login integrations.</li>
-        <li>With our affiliates or otherwise within our corporate group.</li>
-        <li>In connection with a business transaction such as a merger or bankruptcy, to comply with any applicable legal obligations (including to respond to subpoenas, search warrants and similar requests), to enforce any applicable terms of service or policies, and to protect or defend the Services, our rights, and the rights of our users or others.</li>
+        <li>With the service providers who help us run the Services. In practice these are: <strong>Shopify</strong> (online shop, checkout, payment processing and order fulfillment), <strong>Vercel</strong> (website hosting and anonymous performance measurement), <strong>Google Analytics</strong> (website analytics, only if you accept analytics cookies), and <strong>Google Cloud Storage and Google Drive</strong> (hosting the matchday photo gallery). Each uses your information in accordance with its own privacy notice.</li>
+        <li>When you direct, request us or otherwise consent to our disclosure of certain information to third parties, such as to ship you products.</li>
+        <li>In connection with a business transaction such as a merger or bankruptcy, to comply with any applicable legal obligations (including to respond to subpoenas, search warrants and similar requests), to enforce any applicable policies, and to protect or defend the Services, our rights, and the rights of our users or others.</li>
       </Typography>
 
       <Typography variant="h6" fontWeight="bold" gutterBottom sx={{marginTop: 3}}>
         Relationship with Shopify
       </Typography>
       <Typography paragraph>
-        The Services are hosted by Shopify, which collects and processes personal information about your access to and use of the Services in order to provide and improve the Services for you. Information you submit to the Services will be transmitted to and shared with Shopify as well as third parties that may be located in countries other than where you reside, in order to provide and improve the Services for you. In addition, to help protect, grow, and improve our business, we use certain Shopify enhanced features that incorporate data and information obtained from your interactions with our Store, along with other merchants and with Shopify. To provide these enhanced features, Shopify may make use of personal information collected about your interactions with our store, along with other merchants, and with Shopify. In these circumstances, Shopify is responsible for the processing of your personal information, including for responding to your requests to exercise your rights over use of your personal information for these purposes. To learn more about how Shopify uses your personal information and any rights you may have, you can visit the{' '}
+        miamigooners.com is hosted on Vercel, not on Shopify. Shopify powers our online shop: we use it to look up product and price information, and it hosts the checkout. While you are browsing the shop on this website, you are not sending anything to Shopify beyond the items you put in your cart. When you select "Proceed to Checkout" you leave miamigooners.com and continue on Shopify's own checkout pages, where Shopify collects your contact, shipping and payment details directly. From that point Shopify is responsible for processing your personal information, including responding to requests to exercise your rights over it, and its own privacy policy applies. Shopify may transfer and process that information in countries other than where you reside. To learn more about how Shopify uses your personal information and any rights you may have, you can visit the{' '}
         <Link href="https://www.shopify.com/legal/privacy/customers" target="_blank" rel="noopener noreferrer">
           Shopify Consumer Privacy Policy
         </Link>.
@@ -104,6 +101,17 @@ export const PrivacyPolicy = () => {
       </Typography>
 
       <Typography variant="h6" fontWeight="bold" gutterBottom sx={{marginTop: 3}}>
+        Matchday Photos
+      </Typography>
+      <Typography paragraph>
+        We publish photographs and videos taken at our matchday events and other club gatherings in the matchday photo gallery on this website. These images are taken in a public or semi-public venue and may show people who attended, including you. Each set of photos is credited using the display name of the club member who contributed it; we do not publish contributors' email addresses. The images are stored in Google Drive and served through Google Cloud Storage.
+      </Typography>
+      <Typography paragraph>
+        If you appear in a photograph and would like it removed, or you contributed photos and want your credit changed or taken down, email us at{' '}
+        <Link href="mailto:info@miamigooners.com">info@miamigooners.com</Link> and we will remove it.
+      </Typography>
+
+      <Typography variant="h6" fontWeight="bold" gutterBottom sx={{marginTop: 3}}>
         Third Party Websites and Links
       </Typography>
       <Typography paragraph>
@@ -124,7 +132,7 @@ export const PrivacyPolicy = () => {
         Please be aware that no security measures are perfect or impenetrable, and we cannot guarantee "perfect security." In addition, any information you send to us may not be secure while in transit. We recommend that you do not use unsecure channels to communicate sensitive or confidential information to us.
       </Typography>
       <Typography paragraph>
-        How long we retain your personal information depends on different factors, such as whether we need the information to maintain your account, to provide you with Services, comply with legal obligations, resolve disputes or enforce other applicable contracts and policies.
+        How long we retain your personal information depends on different factors, such as whether we need the information to provide you with Services, comply with legal obligations, resolve disputes or enforce other applicable contracts and policies.
       </Typography>
 
       <Typography variant="h6" fontWeight="bold" gutterBottom sx={{marginTop: 3}}>
@@ -138,12 +146,12 @@ export const PrivacyPolicy = () => {
         <li><strong>Right to Delete.</strong> You may have a right to request that we delete personal information we maintain about you.</li>
         <li><strong>Right to Correct.</strong> You may have a right to request that we correct inaccurate personal information we maintain about you.</li>
         <li><strong>Right of Portability.</strong> You may have a right to receive a copy of the personal information we hold about you and to request that we transfer it to a third party, in certain circumstances and with certain exceptions.</li>
-        <li><strong>Right to Opt out of Sale or Sharing for Targeted Advertising.</strong> Depending on where you reside, you may have a right to opt out of the "sale" or "share" of your personal information or to opt out of the processing of your personal information for purposes considered to be "targeted advertising", as defined in applicable privacy laws. Please note that if you visit our website with the Global Privacy Control opt-out preference signal enabled, depending on where you are, we will automatically treat this as a request to opt-out for the device and browser that you use to visit the website. If we are able to associate the device sending the signal to a Shopify account, we will apply the opt out request to the account as well. To learn more about Global Privacy Control, you can visit{' '}
+        <li><strong>Right to Opt out of Sale or Sharing for Targeted Advertising.</strong> Depending on where you reside, you may have a right to opt out of the "sale" or "share" of your personal information or to opt out of the processing of your personal information for purposes considered to be "targeted advertising", as defined in applicable privacy laws. We do not currently sell your personal information, or share it for cross-context behavioral or targeted advertising. If you visit our website with the Global Privacy Control opt-out preference signal enabled, we automatically treat this as a request to opt out for that device and browser, and we will not set analytics cookies. To learn more about Global Privacy Control, you can visit{' '}
           <Link href="https://globalprivacycontrol.org/" target="_blank" rel="noopener noreferrer">
             https://globalprivacycontrol.org/
           </Link>. Other than the Global Privacy Control, we do not recognize other "Do Not Track" signals that may be sent from your web browser or device.
         </li>
-        <li><strong>Managing Communication Preferences.</strong> We may send you promotional emails, and you may opt out of receiving these at any time by using the unsubscribe option displayed in our emails to you. If you opt out, we may still send you non-promotional emails, such as those about your account or orders that you have made.</li>
+        <li><strong>Email We Send You.</strong> We do not run email marketing campaigns and we do not have a newsletter. If you buy something, Shopify sends you transactional email about that order — order confirmation, shipping and delivery updates, and any return you request. If we ever start sending promotional email, it will include an unsubscribe option.</li>
       </Typography>
       <Typography paragraph>
         You may exercise any of these rights where indicated on the Services or by contacting us using the contact details provided below. To learn more about how Shopify uses your personal information and any rights you may have, including rights related to data processed by Shopify, you can visit{' '}

--- a/src/policies/ReturnPolicy.tsx
+++ b/src/policies/ReturnPolicy.tsx
@@ -8,6 +8,10 @@ export const ReturnPolicy = () => {
       </Typography>
 
       <Typography paragraph>
+        <strong>Where we ship.</strong> Most items ship domestically within the United States only. Certain items are also available for international delivery, including to the European Union — those items are marked <strong>"international shipping available"</strong> on their product page. If an item is not marked that way, we can only ship it to a US address.
+      </Typography>
+
+      <Typography paragraph>
         To be eligible for a return, your item must be in the same condition that you received it, unworn or unused, with tags, and in its original packaging. You'll also need the receipt or proof of purchase.
       </Typography>
 
@@ -53,7 +57,7 @@ export const ReturnPolicy = () => {
         European Union 14 day cooling off period
       </Typography>
       <Typography paragraph>
-        Notwithstanding the above, if the merchandise is being shipped into the European Union, you have the right to cancel or return your order within 14 days, for any reason and without a justification. As above, your item must be in the same condition that you received it, unworn or unused, with tags, and in its original packaging. You'll also need the receipt or proof of purchase.
+        This applies only to the items we offer for international delivery, which are marked "international shipping available" on their product page — we do not ship other items into the European Union. Where merchandise is being shipped into the European Union, you have the right to cancel or return your order within 14 days, for any reason and without a justification. As above, your item must be in the same condition that you received it, unworn or unused, with tags, and in its original packaging. You'll also need the receipt or proof of purchase.
       </Typography>
 
       <Typography variant="h6" fontWeight="bold" gutterBottom sx={{marginTop: 3}}>

--- a/src/types/photos.ts
+++ b/src/types/photos.ts
@@ -1,6 +1,5 @@
 export interface DriveOwner {
   displayName: string
-  emailAddress: string
   photoLink?: string
 }
 

--- a/src/utils/consent.ts
+++ b/src/utils/consent.ts
@@ -1,0 +1,29 @@
+export const CONSENT_STORAGE_KEY = 'miami-gooners-cookie-consent-v1'
+export const CONSENT_OPEN_EVENT = 'miami-gooners:open-cookie-settings'
+
+export type ConsentValue = 'granted' | 'denied'
+
+// localStorage throws in Safari private mode and when storage is disabled, so
+// every access is guarded — the banner must still work, it just won't persist.
+export const readConsent = (): ConsentValue | null => {
+  try {
+    const stored = localStorage.getItem(CONSENT_STORAGE_KEY)
+    return stored === 'granted' || stored === 'denied' ? stored : null
+  } catch {
+    return null
+  }
+}
+
+export const writeConsent = (value: ConsentValue) => {
+  try {
+    localStorage.setItem(CONSENT_STORAGE_KEY, value)
+  } catch {
+    // ignore
+  }
+}
+
+// Google Consent Mode v2 — GA4 is loaded with analytics_storage denied and
+// upgraded here once the visitor chooses. Until then it sets no cookies.
+export const updateGtagConsent = (value: ConsentValue) => {
+  window.gtag?.('consent', 'update', {analytics_storage: value})
+}

--- a/src/utils/googleDrive.ts
+++ b/src/utils/googleDrive.ts
@@ -16,11 +16,30 @@ function emptyPhotosData(): PhotosData {
   }
 }
 
+// Older manifests carried an emailAddress on every owner. This whole object is
+// handed to a client component, so anything left on it ships to the browser —
+// drop the field on read rather than waiting for the manifest to be re-synced.
+function stripOwnerEmails(data: PhotosData): PhotosData {
+  return {
+    ...data,
+    matches: data.matches.map((match) => ({
+      ...match,
+      files: match.files.map((file) => ({
+        ...file,
+        owners: (file.owners ?? []).map(({displayName, photoLink}) => ({
+          displayName,
+          photoLink,
+        })),
+      })),
+    })),
+  }
+}
+
 export async function getMatchPhotos(): Promise<PhotosData> {
   try {
     const res = await fetch(MANIFEST_URL, {next: {revalidate: 300}})
     if (!res.ok) throw new Error(`Manifest fetch failed: ${res.status}`)
-    return res.json()
+    return stripOwnerEmails(await res.json())
   } catch (error) {
     console.error('Error fetching photo manifest:', error)
     return emptyPhotosData()

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,3 +1,14 @@
+declare global {
+	interface Window {
+		dataLayer?: unknown[];
+		gtag?: (...args: unknown[]) => void;
+	}
+	interface Navigator {
+		// Global Privacy Control opt-out signal — honoured per our Privacy Policy
+		globalPrivacyControl?: boolean;
+	}
+}
+
 export interface EventType {
 	MatchNumber: number;
 	RoundNumber: number;


### PR DESCRIPTION
## Why

Google Analytics was loading on every page and writing `_ga` cookies before visitors had any chance to consent. Auditing that surfaced two further issues: the privacy policy was unmodified Shopify boilerplate describing a site we don't have, and the photo sync was publishing contributors' personal email addresses.

## ⚠️ Needs a manual step after merge

`scripts/sync-thumbnails.mjs` was requesting `owners(emailAddress)` from the Drive API and writing it into `manifest.json` — a **publicly readable** GCS object that is also handed whole to a client component, so the addresses were serialized into every visitor's page payload on `/matchday-photos`. Fetching the manifest unauthenticated returns two personal Gmail addresses plus the club address, across 1,359 `emailAddress` blocks. Only `displayName` was ever rendered, so nothing needed the field.

This PR stops it at the source and strips the field on read, so the site stops republishing them as soon as this deploys. **The deployed `manifest.json` keeps the addresses until `npm run sync-photos` is re-run**, which needs the Google service-account credentials. Worth doing promptly — the GCS URL is directly fetchable in the meantime.

## Cookie consent

GA4 now boots with `analytics_storage: denied` under Google Consent Mode v2 and upgrades only when a visitor accepts. Until then it sets no cookies.

- Bottom banner with equally prominent **Accept** and **Reject** — rejecting has to be as easy as accepting — plus a Privacy Policy link. Mounted in the root layout so it also covers `not-found`.
- Footer **Cookie Preferences** link, so consent can be withdrawn as easily as it was given.
- Global Privacy Control is honored. The privacy policy already promised this; nothing implemented it.

One subtlety worth a reviewer's eye: the gtag loader is injected from the same inline script that queues the consent default, rather than being a JSX `<script async src>`. React hoists those into `<head>`, which would let the library run before the consent default was set.

## Privacy policy

Removed what isn't true here — accounts, usernames, passwords, security questions, wishlists, product reviews, "hosted by Shopify", the Terms of Service reference (no such document exists), online behavioral advertising, marketing partner sharing, and the "affiliates / corporate group" clause.

Replaced with what the site actually does: no forms of any kind, the cart holds variant IDs only, and all contact, shipping and payment data is collected on Shopify's hosted checkout after the redirect. Names the four real processors (Shopify, Vercel, Google Analytics, Google Cloud), documents the actual cookie and storage inventory, and adds a **Matchday Photos** section with a takedown contact — the gallery publishes photos of identifiable people and was not mentioned at all.

## Shipping scope

The Return Policy read as though everything shipped to the EU. It now states orders ship within the US unless an item is marked "international shipping available", and scopes the EU 14-day cooling-off right to those items.

## Also fixed

- `CartContext` accessed `localStorage` unguarded, which threw when storage is blocked and crashed the React tree — taking the consent banner down with it, for exactly the privacy-conscious users who most need it.
- Dropped the stale Auth0 references from `CLAUDE.md`. There is no Auth0 in this codebase, and the doc sends privacy reviews chasing cookies that don't exist.

## Verification

`npm run build` passes clean including TypeScript. 46 browser checks pass via Playwright, covering: no `_ga` cookie before a choice, the consent default queued before `config`, accept/reject persistence across reloads, the footer link reopening the banner, GPC suppression, storage-disabled resilience, the removed policy claims being absent and the new text present, and no `@gmail.com` or `emailAddress` anywhere in the `/matchday-photos` payload.

Two caveats, stated plainly:

- **The real "accept → `_ga` cookie appears" leg is unverified.** The sandbox blocks `googletagmanager.com`, so gtag.js never actually loaded. The request fires and the dataLayer semantics are correct, but please confirm `gcs=G111` in DevTools on a preview deploy.
- `npm run lint` is broken independently of these changes — `next lint` was removed in Next 16 and there is no ESLint config in the repo.

## Not addressed

Both policies publish the street address `2852 SW 35th Ave`; the Return Policy still excludes perishable goods and flammable liquids for a t-shirt shop; and there is still no linkable `/privacy` route (policies are modal-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXEJLriJVbMZB97duDcgts

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXEJLriJVbMZB97duDcgts)_