### PR TITLE
Add Emirates Cup result vs Borussia Dortmund

### DIFF
--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -50,6 +50,8 @@ const preSeason: EventType[] = [
     Location: 'Emirates Stadium',
     HomeTeam: 'Arsenal',
     AwayTeam: 'Borussia Dortmund',
+    HomeTeamScore: 2,
+    AwayTeamScore: 3,
     competition: 'Emirates Cup',
   },
   {


### PR DESCRIPTION
Arsenal 2-3 Borussia Dortmund at the Emirates on 9 August 2026.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C2wqBxSdbrDBkFGKd47Mwd